### PR TITLE
make a real toolsuite out of it

### DIFF
--- a/.shed.yml
+++ b/.shed.yml
@@ -3,3 +3,13 @@ long_description: This method utilizes monomeric protein structure predictions t
 homepage_url: https://github.com/guerler/springsuite
 name: springsuite
 owner: guerler
+type: unrestricted
+categories:
+ - Sequence Analysis
+auto_tool_repositories:
+  name_template: "{{ tool_id }}"
+  description_template: "Spring Suite: {{ tool_name }}."
+suite:
+  name: "suite_springsuite"
+  description: "A suite of Galaxy tools designed for the SpringSuite for identification of protein-protein interactions."
+  type: repository_suite_definition

--- a/.shed.yml
+++ b/.shed.yml
@@ -8,8 +8,8 @@ categories:
  - Sequence Analysis
 auto_tool_repositories:
   name_template: "{{ tool_id }}"
-  description_template: "Spring Suite: {{ tool_name }}."
+  description_template: "SpringSuite: {{ tool_name }}."
 suite:
   name: "suite_springsuite"
-  description: "A suite of Galaxy tools designed for the SpringSuite for identification of protein-protein interactions."
+  description: "A suite of tools designed for the identification and structural modeling of protein-protein interactions"
   type: repository_suite_definition


### PR DESCRIPTION
@guerler this is making a real tool suite out of. The IUC is recommending single-tool repositories and this file will now tell planemo to decompose our tools into separate repositories.

I do think this is the correct way to do it, but it creates new ToolShed repos (and with this new tools) and therefore breaks your workflows. So quite a heavy modification :(